### PR TITLE
Outputting prerelease/patch/minor/major/release/build tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
+        with:
+          compare-against: 0.0.0
         id: semver-tag
-        compare-against: 0.0.0
       - name: Install semver-tool
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
           planned: 1000000000.0.0
           post-planned: 1000000000.0.1
         id: billionth
+      - name: Run local action with repo=lf-lang/lingua-franca
+        uses: ./
+        with:
+          repo: lf-lang/lingua-franca
+          path: lingua-franca
+        id: semver-tag
       - name: Install semver-tool
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
         run: |
           [[ ! -z "${{ steps.semver-tag.outputs.current }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.current-bare }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.patch }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.patch-bare }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.minor }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.minor-bare }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.major }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.major-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-patch }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-patch-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-minor }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-minor-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-major }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-major-bare }}" ]] || exit 1
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
           [[ $(semver compare ${{ steps.greatest-semver-tag.outputs.tag }} 0.0.0) -eq 1 ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-release }} ${{ steps.semver-tag.outputs.next-prerelease }}) -eq 1 ]] || exit 1
       - name: Ensure 0.0.0 is not greater than whatever the current version is
         run: |
-          [[ "${{ steps.semver-tag.outputs.input-greater }}" == "false" ]] || exit 1
+          [[ "${{ steps.semver-tag.outputs.planned-is-valid }}" == "false" ]] || exit 1
       - name: Ensure 1000000000.0.0 is greater than whatever the current version is
         run: |
-          [[ "${{ steps.billionth.outputs.input-greater }}" == "true" ]] || exit 1
+          [[ "${{ steps.billionth.outputs.planned-is-valid }}" == "true" ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
-        id: greatest-semver-tag
+        id: semver-tag
       - name: Install semver-tool
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
@@ -18,8 +18,14 @@ jobs:
           semver --version
       - name: Ensure outputs are not empty
         run: |
-          [[ ! -z "${{ steps.greatest-semver-tag.outputs.tag }}" ]] || exit 1
-          [[ ! -z "${{ steps.greatest-semver-tag.outputs.no-prefix }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.current }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.current-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.patch }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.patch-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.minor }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.minor-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.major }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.major-bare }}" ]] || exit 1
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
           [[ $(semver compare ${{ steps.greatest-semver-tag.outputs.tag }} 0.0.0) -eq 1 ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           repo: lf-lang/lingua-franca
           path: lingua-franca
-        id: semver-tag
       - name: Install semver-tool
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           planned: 1000000000.0.0
           post-planned: 1000000000.0.1
         id: billionth
+      - name: Run local action with build=foo
+        uses: ./
+        with:
+          build: foo
+        id: foo-build
       - name: Run local action with repo=lf-lang/lingua-franca
         uses: ./
         with:
@@ -55,3 +60,6 @@ jobs:
       - name: Ensure 1000000000.0.1 is greater than 1000000000.0.0
         run: |
           [[ "${{ steps.billionth.outputs.post-planned-is-valid }}" == "true" ]] || exit 1
+      - name: Ensure next-build of foo-build is foo
+        run: |
+          [[ "$(semver get build ${{ steps.foo-build.outputs.next-build }})" == "foo" ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: ./
         with:
           planned: 1000000000.0.0
+          post-planned: 1000000000.0.1
         id: billionth
       - name: Install semver-tool
         run: |
@@ -44,3 +45,6 @@ jobs:
       - name: Ensure 1000000000.0.0 is greater than whatever the current version is
         run: |
           [[ "${{ steps.billionth.outputs.planned-is-valid }}" == "true" ]] || exit 1
+      - name: Ensure 1000000000.0.1 is greater than 1000000000.0.0
+        run: |
+          [[ "${{ steps.billionth.outputs.post-planned-is-valid }}" == "true" ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,8 @@ jobs:
           [[ ! -z "${{ steps.semver-tag.outputs.next-major-bare }}" ]] || exit 1
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
-          [[ $(semver compare ${{ steps.greatest-semver-tag.outputs.tag }} 0.0.0) -eq 1 ]] || exit 1
-          [[ $(semver compare ${{ steps.greatest-semver-tag.outputs.no-prefix }} 0.0.0) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.current }} 0.0.0) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.current-bare }} 0.0.0) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.next-patch }} ${{ steps.semver-tag.outputs.current }}) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.next-minor }} ${{ steps.semver-tag.outputs.next-patch }}) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.next-major }} ${{ steps.semver-tag.outputs.next-minor }}) -eq 1 ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,11 @@ jobs:
       - name: Ensure outputs are not empty
         run: |
           [[ ! -z "${{ steps.semver-tag.outputs.current }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.current-bare }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-patch }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.next-patch-bare }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-minor }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.next-minor-bare }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-major }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.next-major-bare }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-release }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-prerelease }}" ]] || exit 1
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
           [[ $(semver compare ${{ steps.semver-tag.outputs.current }} 0.0.0) -eq 1 ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         id: semver-tag
+        compare-against: 0.0.0
       - name: Install semver-tool
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
@@ -24,7 +25,6 @@ jobs:
           [[ ! -z "${{ steps.semver-tag.outputs.next-major }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-prerelease }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-release }}" ]] || exit 1
-          
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
           [[ $(semver compare ${{ steps.semver-tag.outputs.current }} 0.0.0) -eq 1 ]] || exit 1
@@ -33,3 +33,6 @@ jobs:
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-minor }} ${{ steps.semver-tag.outputs.next-patch }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-major }} ${{ steps.semver-tag.outputs.next-minor }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-release }} ${{ steps.semver-tag.outputs.next-prerelease }}) -eq 1 ]] || exit 1
+      - name: Ensure 0.0.0 is not greater than whatever the current version is
+        run: |
+          [[ "${{ steps.semver-tag.outputs.input-greater }}" == "false" ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         with:
-          compare-against: 0.0.0
+          planned: 0.0.0
         id: semver-tag
+      - uses: ./
+        with:
+          planned: 1000000000.0.0
+        id: billionth
       - name: Install semver-tool
         run: |
           wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
@@ -37,3 +41,6 @@ jobs:
       - name: Ensure 0.0.0 is not greater than whatever the current version is
         run: |
           [[ "${{ steps.semver-tag.outputs.input-greater }}" == "false" ]] || exit 1
+      - name: Ensure 1000000000.0.0 is greater than whatever the current version is
+        run: |
+          [[ "${{ steps.billionth.outputs.input-greater }}" == "true" ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Run local action with planned=0.0.0
+        uses: actions/checkout@v3
       - uses: ./
         with:
           planned: 0.0.0
         id: semver-tag
-      - uses: ./
+      - name: Run local action with planned=1000000000.0.0, post-planned=1000000000.0.1
+        uses: ./
         with:
           planned: 1000000000.0.0
           post-planned: 1000000000.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Run local action with planned=0.0.0
-        uses: actions/checkout@v3
-      - uses: ./
+        uses: ./
         with:
           planned: 0.0.0
         id: semver-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
           [[ $(semver compare ${{ steps.semver-tag.outputs.current }} 0.0.0) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.next-prerelease }} ${{ steps.semver-tag.outputs.current }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-patch }} ${{ steps.semver-tag.outputs.current }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-minor }} ${{ steps.semver-tag.outputs.next-patch }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-major }} ${{ steps.semver-tag.outputs.next-minor }}) -eq 1 ]] || exit 1
-          [[ $(semver compare ${{ steps.semver-tag.outputs.next-prerelease }} ${{ steps.semver-tag.outputs.next-major }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-release }} ${{ steps.semver-tag.outputs.next-prerelease }}) -eq 1 ]] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,14 @@ jobs:
           [[ ! -z "${{ steps.semver-tag.outputs.next-patch }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-minor }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-major }}" ]] || exit 1
-          [[ ! -z "${{ steps.semver-tag.outputs.next-release }}" ]] || exit 1
           [[ ! -z "${{ steps.semver-tag.outputs.next-prerelease }}" ]] || exit 1
+          [[ ! -z "${{ steps.semver-tag.outputs.next-release }}" ]] || exit 1
+          
       - name: Ensure outputs are semver and greater than 0.0.0
         run: |
           [[ $(semver compare ${{ steps.semver-tag.outputs.current }} 0.0.0) -eq 1 ]] || exit 1
-          [[ $(semver compare ${{ steps.semver-tag.outputs.current-bare }} 0.0.0) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-patch }} ${{ steps.semver-tag.outputs.current }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-minor }} ${{ steps.semver-tag.outputs.next-patch }}) -eq 1 ]] || exit 1
           [[ $(semver compare ${{ steps.semver-tag.outputs.next-major }} ${{ steps.semver-tag.outputs.next-minor }}) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.next-prerelease }} ${{ steps.semver-tag.outputs.next-major }}) -eq 1 ]] || exit 1
+          [[ $(semver compare ${{ steps.semver-tag.outputs.next-release }} ${{ steps.semver-tag.outputs.next-prerelease }}) -eq 1 ]] || exit 1

--- a/action.yml
+++ b/action.yml
@@ -23,9 +23,12 @@ inputs:
     required: false
 
 outputs:
+  tag:
+    description: Tag corresponding to current version
+    value: ${{ steps.find.outputs.tag }}    
   current:
-    description: Current semver tag
-    value: ${{ steps.find.outputs.tag }}
+    description: Current version
+    value: ${{ steps.find.outputs.ver }}
   next-prerelease:
     description: Prerelease increment (over current semver tag)
     value: ${{ steps.incr.outputs.prerelease }}  
@@ -80,8 +83,13 @@ runs:
     - name: Find the greatest semver tag
       id: find
       working-directory: ${{ inputs.path }}
-      run: |
+      run: >
+        tag=$(greatest-semver-tag)
         echo "::set-output name=tag::$(greatest-semver-tag)"
+        rel="$(semver get release $tag)"
+        pre="$(semver get prerel $tag)"
+        build="$(semver get build $tag)"
+        echo "::set-output name=ver::$rel-$pre+build"
       shell: bash
     - name: Test if planned input is greater than output
       id: test
@@ -120,8 +128,9 @@ runs:
       if: ${{ inputs.build != '' }}
     - name: Print results
       run: |
+        echo "Greatest tag: ${{ steps.find.outputs.tag }}"
+        echo "Current version: ${{ steps.find.outputs.ver }}"
         echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"
-        echo "Current tag: ${{ steps.find.outputs.tag }}"
         echo "Patch increment: ${{ steps.incr.outputs.patch }}"
         echo "Minor increment: ${{ steps.incr.outputs.minor }}"
         echo "Major increment: ${{ steps.incr.outputs.major }}"

--- a/action.yml
+++ b/action.yml
@@ -88,11 +88,17 @@ runs:
       shell: bash
     - name: Construct version from tag
       id: construct
-      run: >
-        rel="$(semver get release $tag)"
-        pre="$(semver get prerel $tag)"
-        build="$(semver get build $tag)"
-        echo "::set-output name=ver::$rel-$pre+build"
+      run: |
+        rel="$(semver get release $tag)";
+        pre="$(semver get prerel $tag)";
+        build="$(semver get build $tag)";
+        if [[ $pre != "" ]]; then
+          pre="-$pre"
+        fi
+        if [[ $build != "" ]]; then
+          build="+$build"
+        fi
+        echo "::set-output name=ver::$rel$pre$build"
       shell: bash
     - name: Test if planned input is greater than output
       id: test

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
           echo "::set-output name=greater::false"
         fi
       shell: bash
-      if: ${{ inputs.test-if-greater != '' }}
+      if: ${{ inputs.compare-against != '' }}
     - name: Produce increments
       id: incr
       run: |

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     type: string
     description: Version of a planned release
     required: false
+  post-planned:
+    type: string
+    description: Version after planned release
+    required: false
 
 outputs:
   current:
@@ -36,6 +40,10 @@ outputs:
   planned-is-valid:
     description: True if planned input is valid semver greater than current
     value: ${{ steps.test.outputs.greater }}
+  post-planned-is-valid:
+    description: True if post-planned input is valid semver greater planned
+    value: ${{ steps.test-post.outputs.greater }}
+
 branding:
   icon: tag
   color: green
@@ -78,6 +86,16 @@ runs:
         fi
       shell: bash
       if: ${{ inputs.planned != '' }}
+    - name: Test if post-planned input is greater than planned input
+      id: test-post
+      run: >
+        if [[ $(semver compare ${{ inputs.post-planned }} ${{ inputs.planned }}) -eq 1 ]]; then
+          echo "::set-output name=greater::true"
+        else
+          echo "::set-output name=greater::false"
+        fi
+      shell: bash
+      if: ${{ inputs.planned != '' && inputs.post-planned != '' }}
     - name: Produce increments
       id: incr
       run: |

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,7 @@ runs:
         if [[ $(semver compare ${{ inputs.test-if-greater }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
           echo "::set-output name=greater::true"
         fi
+      shell: bash
       if: ${{ inputs.test-if-greater != '' }}
     - name: Produce increments
       id: incr

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,8 @@ runs:
       run: |
         echo "::set-output name=tag::$(greatest-semver-tag)"
       shell: bash
-    - name: Compare test-if-greater input to current output
+    - name: Test if compare-against input is greater than output
+      id: test
       run: >
         if [[ $(semver compare ${{ inputs.test-if-greater }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
           echo "::set-output name=greater::true"

--- a/action.yml
+++ b/action.yml
@@ -89,16 +89,16 @@ runs:
     - name: Construct version from tag
       id: construct
       run: |
-        rel="$(semver get release $tag)";
-        pre="$(semver get prerel $tag)";
-        build="$(semver get build $tag)";
+        rel="$(semver get release ${{ steps.find.outputs.tag }})";
+        pre="$(semver get prerel ${{ steps.find.outputs.tag }})";
+        bld="$(semver get build ${{ steps.find.outputs.tag }})";
         if [[ $pre != "" ]]; then
           pre="-$pre"
         fi
-        if [[ $build != "" ]]; then
-          build="+$build"
+        if [[ $bld != "" ]]; then
+          bld="+$bld"
         fi
-        echo "::set-output name=ver::$rel$pre$build"
+        echo "::set-output name=ver::$rel$pre$bld"
       shell: bash
     - name: Test if planned input is greater than output
       id: test

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,7 @@ runs:
         pre="$(semver get prerel $tag)"
         build="$(semver get build $tag)"
         echo "::set-output name=ver::$rel-$pre+build"
+      shell: bash
     - name: Test if planned input is greater than output
       id: test
       run: >

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,18 @@
 name: SemVer Tag
-description: Find the greatest semantic version tag and return it, along with a patch, minor, and major increment.
+description: Find the greatest semantic version tag and return it, along with a prerelease, patch, minor, major, and release increment.
 inputs:
   path:
     type: string
     description: Path to the repository
     default: ${{ github.workspace }}
-  prefix:
+  repo:
     type: string
-    description: Prefix used in version tags
-    default: 'v'
+    description: Name of repository to check out
+    required: false
+  compare-against:
+    type: string
+    description: Version to compare against the current
+    required: false
 
 outputs:
   current:
@@ -29,7 +33,9 @@ outputs:
   next-release:
     description: Release increment (over current semver tag)
     value: ${{ steps.incr.outputs.release }}
-
+  input-greater:
+    description: True if compare-against input is greater than current output
+    value: ${{ steps.test.outputs.greater }}
 branding:
   icon: tag
   color: green
@@ -56,6 +62,12 @@ runs:
       run: |
         echo "::set-output name=tag::$(greatest-semver-tag)"
       shell: bash
+    - name: Compare test-if-greater input to current output
+      run: >
+        if [[ $(semver compare ${{ inputs.test-if-greater }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
+          echo "::set-output name=greater::true"
+        fi
+      if: ${{ inputs.test-if-greater != '' }}
     - name: Produce increments
       id: incr
       run: |

--- a/action.yml
+++ b/action.yml
@@ -14,27 +14,21 @@ outputs:
   current:
     description: Current semver tag
     value: ${{ steps.find.outputs.tag }}
-  current-bare:
-    description: "Current semver tag stripped from leading 'v'"
-    value: ${{ steps.strip.outputs.ver }}
   next-patch:
     description: Patch increment (over current semver tag)
     value: ${{ steps.incr.outputs.patch }}
-  next-patch-bare:
-    description: "Patch increment stripped from leading 'v'"
-    value: ${{ steps.strip.outputs.patch }}
   next-minor:
     description: Minor increment (over current semver tag)
     value: ${{ steps.incr.outputs.minor }}
-  next-minor-bare:
-    description: "Minor increment stripped from leading 'v'"
-    value: ${{ steps.strip.outputs.minor }}
   next-major:
     description: Major increment (over current semver tag)
     value: ${{ steps.incr.outputs.major }}
-  next-major-bare:
-    description: "Major increment stripped from leading 'v'"
-    value: ${{ steps.strip.outputs.major }}
+  next-release:
+    description: Release increment (over current semver tag)
+    value: ${{ steps.incr.outputs.release }}
+  next-prerelease:
+    description: Prerelease increment (over current semver tag)
+    value: ${{ steps.incr.outputs.prerelease }}  
 
 branding:
   icon: tag
@@ -68,19 +62,15 @@ runs:
         echo "::set-output name=patch::$(semver bump patch ${{ steps.find.outputs.tag }})"
         echo "::set-output name=minor::$(semver bump minor ${{ steps.find.outputs.tag }})"
         echo "::set-output name=major::$(semver bump major ${{ steps.find.outputs.tag }})"
+        echo "::set-output name=release::$(semver bump release ${{ steps.find.outputs.tag }})"
+        echo "::set-output name=prerelease::$(semver bump prerel ${{ steps.find.outputs.tag }})"
       shell: bash  
-    - name: Produce bare versions (without leading 'v')
-      id: strip
-      run: |
-        tag="${{ steps.find.outputs.tag }}" && shopt -s extglob && echo "::set-output name=ver::${tag##v}"
-        tag="${{ steps.incr.outputs.patch }}" && shopt -s extglob && echo "::set-output name=patch::${tag##v}"
-        tag="${{ steps.incr.outputs.minor }}" && shopt -s extglob && echo "::set-output name=minor::${tag##v}"
-        tag="${{ steps.incr.outputs.major }}" && shopt -s extglob && echo "::set-output name=major::${tag##v}"
-      shell: bash
     - name: Print results
       run: |
         echo "Current tag: ${{ steps.find.outputs.tag }}"
         echo "Patch increment: ${{ steps.incr.outputs.patch }}"
         echo "Minor increment: ${{ steps.incr.outputs.minor }}"
         echo "Major increment: ${{ steps.incr.outputs.major }}"
+        echo "Release increment: ${{ steps.incr.outputs.release }}"
+        echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
     - name: Test if compare-against input is greater than output
       id: test
       run: >
-        if [[ $(semver compare ${{ inputs.test-if-greater }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
+        if [[ $(semver compare ${{ inputs.planned }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
           echo "::set-output name=greater::true"
         else
           echo "::set-output name=greater::false"

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,9 @@ inputs:
     type: string
     description: Name of repository to check out
     required: false
-  compare-against:
+  planned:
     type: string
-    description: Version to compare against the current
+    description: Version of a planned release
     required: false
 
 outputs:
@@ -33,8 +33,8 @@ outputs:
   next-release:
     description: Release increment (over current semver tag)
     value: ${{ steps.incr.outputs.release }}
-  input-greater:
-    description: True if compare-against input is greater than current output
+  planned-is-valid:
+    description: True if planned input is valid semver greater than current
     value: ${{ steps.test.outputs.greater }}
 branding:
   icon: tag

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
     value: ${{ steps.find.outputs.tag }}    
   current:
     description: Current version
-    value: ${{ steps.construct.outputs.ver }}
+    value: ${{ steps.cur.outputs.ver }}
   next-prerelease:
     description: Prerelease increment (over current semver tag)
     value: ${{ steps.incr.outputs.prerelease }}  
@@ -86,19 +86,10 @@ runs:
       run: |
         echo "::set-output name=tag::$(greatest-semver-tag)"
       shell: bash
-    - name: Construct version from tag
-      id: construct
+    - name: Set current version based on stripped tag
+      id: cur
       run: |
-        rel="$(semver get release ${{ steps.find.outputs.tag }})";
-        pre="$(semver get prerel ${{ steps.find.outputs.tag }})";
-        bld="$(semver get build ${{ steps.find.outputs.tag }})";
-        if [[ $pre != "" ]]; then
-          pre="-$pre"
-        fi
-        if [[ $bld != "" ]]; then
-          bld="+$bld"
-        fi
-        echo "::set-output name=ver::$rel$pre$bld"
+        echo "::set-output name=ver::$(echo "${{ steps.find.outputs.tag }}" | sed 's/^[^0-9]*//')"
       shell: bash
     - name: Test if planned input is greater than output
       id: test

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ runs:
       run: >
         if [[ $(semver compare ${{ inputs.test-if-greater }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
           echo "::set-output name=greater::true"
+        else
+          echo "::set-output name=greater::false"
         fi
       shell: bash
       if: ${{ inputs.test-if-greater != '' }}

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ outputs:
   current:
     description: Current semver tag
     value: ${{ steps.find.outputs.tag }}
+  next-prerelease:
+    description: Prerelease increment (over current semver tag)
+    value: ${{ steps.incr.outputs.prerelease }}  
   next-patch:
     description: Patch increment (over current semver tag)
     value: ${{ steps.incr.outputs.patch }}
@@ -23,9 +26,6 @@ outputs:
   next-major:
     description: Major increment (over current semver tag)
     value: ${{ steps.incr.outputs.major }}
-  next-prerelease:
-    description: Prerelease increment (over current semver tag)
-    value: ${{ steps.incr.outputs.prerelease }}  
   next-release:
     description: Release increment (over current semver tag)
     value: ${{ steps.incr.outputs.release }}
@@ -67,10 +67,10 @@ runs:
       shell: bash  
     - name: Print results
       run: |
+        echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"
         echo "Current tag: ${{ steps.find.outputs.tag }}"
         echo "Patch increment: ${{ steps.incr.outputs.patch }}"
         echo "Minor increment: ${{ steps.incr.outputs.minor }}"
         echo "Major increment: ${{ steps.incr.outputs.major }}"
-        echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"
         echo "Release increment: ${{ steps.incr.outputs.release }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,12 @@ branding:
 runs:
   using: composite
   steps:
+    - name: Check out repository if one is specified
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ inputs.repo }}
+        path: ${{ inputs.path }}
+      if: ${{ inputs.repo != '' }}
     - name: Install semver-tool
       run: |
         wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver

--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ runs:
     - name: Print results
       run: |
         echo "Greatest tag: ${{ steps.find.outputs.tag }}"
-        echo "Current version: ${{ steps.find.outputs.ver }}"
+        echo "Current version: ${{ steps.cur.outputs.ver }}"
         echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"
         echo "Patch increment: ${{ steps.incr.outputs.patch }}"
         echo "Minor increment: ${{ steps.incr.outputs.minor }}"

--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,12 @@ outputs:
   next-major:
     description: Major increment (over current semver tag)
     value: ${{ steps.incr.outputs.major }}
-  next-release:
-    description: Release increment (over current semver tag)
-    value: ${{ steps.incr.outputs.release }}
   next-prerelease:
     description: Prerelease increment (over current semver tag)
     value: ${{ steps.incr.outputs.prerelease }}  
+  next-release:
+    description: Release increment (over current semver tag)
+    value: ${{ steps.incr.outputs.release }}
 
 branding:
   icon: tag
@@ -62,8 +62,8 @@ runs:
         echo "::set-output name=patch::$(semver bump patch ${{ steps.find.outputs.tag }})"
         echo "::set-output name=minor::$(semver bump minor ${{ steps.find.outputs.tag }})"
         echo "::set-output name=major::$(semver bump major ${{ steps.find.outputs.tag }})"
-        echo "::set-output name=release::$(semver bump release ${{ steps.find.outputs.tag }})"
         echo "::set-output name=prerelease::$(semver bump prerel ${{ steps.find.outputs.tag }})"
+        echo "::set-output name=release::$(semver bump release ${{ steps.find.outputs.tag }})"
       shell: bash  
     - name: Print results
       run: |
@@ -71,6 +71,6 @@ runs:
         echo "Patch increment: ${{ steps.incr.outputs.patch }}"
         echo "Minor increment: ${{ steps.incr.outputs.minor }}"
         echo "Major increment: ${{ steps.incr.outputs.major }}"
-        echo "Release increment: ${{ steps.incr.outputs.release }}"
         echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"
+        echo "Release increment: ${{ steps.incr.outputs.release }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       run: |
         echo "::set-output name=tag::$(greatest-semver-tag)"
       shell: bash
-    - name: Test if compare-against input is greater than output
+    - name: Test if planned input is greater than output
       id: test
       run: >
         if [[ $(semver compare ${{ inputs.planned }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
@@ -71,7 +71,7 @@ runs:
           echo "::set-output name=greater::false"
         fi
       shell: bash
-      if: ${{ inputs.compare-against != '' }}
+      if: ${{ inputs.planned != '' }}
     - name: Produce increments
       id: incr
       run: |

--- a/action.yml
+++ b/action.yml
@@ -126,4 +126,5 @@ runs:
         echo "Minor increment: ${{ steps.incr.outputs.minor }}"
         echo "Major increment: ${{ steps.incr.outputs.major }}"
         echo "Release increment: ${{ steps.incr.outputs.release }}"
+        echo "Build increment (if specified): ${{ steps.build.outputs.incr }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -65,9 +65,9 @@ runs:
     - name: Produce increments
       id: incr
       run: |
-        echo "::set-output name=patch::$(semver bump ${{ steps.find.outputs.tag }} patch)"
-        echo "::set-output name=minor::$(semver bump ${{ steps.find.outputs.tag }} minor)"
-        echo "::set-output name=major::$(semver bump ${{ steps.find.outputs.tag }} major)"
+        echo "::set-output name=patch::$(semver bump patch ${{ steps.find.outputs.tag }})"
+        echo "::set-output name=minor::$(semver bump minor ${{ steps.find.outputs.tag }})"
+        echo "::set-output name=major::$(semver bump major ${{ steps.find.outputs.tag }})"
       shell: bash  
     - name: Produce bare versions (without leading 'v')
       id: strip

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     type: string
     description: Version after planned release
     required: false
+  build:
+    type: string
+    description: String to be use in next-build output
+    required: false
 
 outputs:
   current:
@@ -37,6 +41,9 @@ outputs:
   next-release:
     description: Release increment (over current semver tag)
     value: ${{ steps.incr.outputs.release }}
+  next-build:
+    description: Release increment (over current semver tag)
+    value: ${{ steps.build.outputs.incr }}  
   planned-is-valid:
     description: True if planned input is valid semver greater than current
     value: ${{ steps.test.outputs.greater }}
@@ -104,7 +111,13 @@ runs:
         echo "::set-output name=major::$(semver bump major ${{ steps.find.outputs.tag }})"
         echo "::set-output name=prerelease::$(semver bump prerel ${{ steps.find.outputs.tag }})"
         echo "::set-output name=release::$(semver bump release ${{ steps.find.outputs.tag }})"
-      shell: bash  
+      shell: bash
+    - name: Produce build increment if a build string was given
+      id: build
+      run: |
+        echo "::set-output name=incr::$(semver bump build ${{ inputs.build }} ${{ steps.find.outputs.tag }})"
+      shell: bash    
+      if: ${{ inputs.build != '' }}
     - name: Print results
       run: |
         echo "Prerelease increment: ${{ steps.incr.outputs.prerelease }}"

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
     value: ${{ steps.find.outputs.tag }}    
   current:
     description: Current version
-    value: ${{ steps.find.outputs.ver }}
+    value: ${{ steps.construct.outputs.ver }}
   next-prerelease:
     description: Prerelease increment (over current semver tag)
     value: ${{ steps.incr.outputs.prerelease }}  
@@ -83,14 +83,16 @@ runs:
     - name: Find the greatest semver tag
       id: find
       working-directory: ${{ inputs.path }}
-      run: >
-        tag=$(greatest-semver-tag)
+      run: |
         echo "::set-output name=tag::$(greatest-semver-tag)"
+      shell: bash
+    - name: Construct version from tag
+      id: construct
+      run: >
         rel="$(semver get release $tag)"
         pre="$(semver get prerel $tag)"
         build="$(semver get build $tag)"
         echo "::set-output name=ver::$rel-$pre+build"
-      shell: bash
     - name: Test if planned input is greater than output
       id: test
       run: >

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,41 @@
-name: Greatest SemVer Tag
-description: Return the greatest semantic version tag
+name: SemVer Tag
+description: Find the greatest semantic version tag and return it, along with a patch, minor, and major increment.
 inputs:
   path:
     type: string
     description: Path to the repository
     default: ${{ github.workspace }}
+  prefix:
+    type: string
+    description: Prefix used in version tags
+    default: 'v'
+
 outputs:
-  tag:
-    description: Greatest semver tag
+  current:
+    description: Current semver tag
     value: ${{ steps.find.outputs.tag }}
-  no-prefix:
-    description: "Greatest semver tag sans 'v'"
+  current-bare:
+    description: "Current semver tag stripped from leading 'v'"
     value: ${{ steps.strip.outputs.ver }}
+  next-patch:
+    description: Patch increment (over current semver tag)
+    value: ${{ steps.incr.outputs.patch }}
+  next-patch-bare:
+    description: "Patch increment stripped from leading 'v'"
+    value: ${{ steps.strip.outputs.patch }}
+  next-minor:
+    description: Minor increment (over current semver tag)
+    value: ${{ steps.incr.outputs.minor }}
+  next-minor-bare:
+    description: "Minor increment stripped from leading 'v'"
+    value: ${{ steps.strip.outputs.minor }}
+  next-major:
+    description: Major increment (over current semver tag)
+    value: ${{ steps.incr.outputs.major }}
+  next-major-bare:
+    description: "Major increment stripped from leading 'v'"
+    value: ${{ steps.strip.outputs.major }}
+
 branding:
   icon: tag
   color: green
@@ -38,13 +62,25 @@ runs:
       run: |
         echo "::set-output name=tag::$(greatest-semver-tag)"
       shell: bash
-    - name: Strip off 'v' prefix if there is one
+    - name: Produce increments
+      id: incr
+      run: |
+        echo "::set-output name=patch::$(semver bump ${{ steps.find.outputs.tag }} patch)"
+        echo "::set-output name=minor::$(semver bump ${{ steps.find.outputs.tag }} minor)"
+        echo "::set-output name=major::$(semver bump ${{ steps.find.outputs.tag }} major)"
+      shell: bash  
+    - name: Produce bare versions (without leading 'v')
       id: strip
       run: |
         tag="${{ steps.find.outputs.tag }}" && shopt -s extglob && echo "::set-output name=ver::${tag##v}"
+        tag="${{ steps.incr.outputs.patch }}" && shopt -s extglob && echo "::set-output name=patch::${tag##v}"
+        tag="${{ steps.incr.outputs.minor }}" && shopt -s extglob && echo "::set-output name=minor::${tag##v}"
+        tag="${{ steps.incr.outputs.major }}" && shopt -s extglob && echo "::set-output name=major::${tag##v}"
       shell: bash
     - name: Print results
       run: |
-        echo "Latest release tag: ${{ steps.find.outputs.tag }}"
-        echo "Without a leading 'v': ${{ steps.strip.outputs.ver }}"
+        echo "Current tag: ${{ steps.find.outputs.tag }}"
+        echo "Patch increment: ${{ steps.incr.outputs.patch }}"
+        echo "Minor increment: ${{ steps.incr.outputs.minor }}"
+        echo "Major increment: ${{ steps.incr.outputs.major }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   using: composite
   steps:
     - name: Check out repository if one is specified
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ inputs.repo }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
This PR significantly changes how this action works. Overview of new functionality:
 - check out a repo if it is given
 - output current version as stripped down version of tag
 - output next versions of any semver increment
 - check whether given planned release is greater than current release
 - check whether given post-planned release is greater than given planned release
 
Note: all versions are devoid of any prefix that might exist in the greatest tag that is found. Users will have to manually add a prefix if they want one.