### PR TITLE
Remove post-planned and add test for planned-is-valid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,11 @@ jobs:
         with:
           planned: 0.0.0
         id: semver-tag
-      - name: Run local action with bump=major, planned=1000000000.0.0, post-planned=1000000000.0.1
+      - name: Run local action with bump=major, planned=1000000000.0.0
         uses: ./
         with:
           bump: major
           planned: 1000000000.0.0
-          post-planned: 1000000000.0.1
         id: billionth
       - name: Run local action with build=foo
         uses: ./
@@ -57,9 +56,6 @@ jobs:
       - name: Ensure 1000000000.0.0 is greater than whatever the current version is
         run: |
           [[ "${{ steps.billionth.outputs.planned-is-valid }}" = "true" ]] || exit 1
-      - name: Ensure 1000000000.0.1 is greater than 1000000000.0.0
-        run: |
-          [[ "${{ steps.billionth.outputs.post-planned-is-valid }}" = "true" ]] || exit 1
       - name: Check major bump
         run: |
           [[ "${{ steps.billionth.outputs.bump }}" = "${{ steps.billionth.outputs.next-major }}" ]] || exit 1

--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
-# Repo SemVer
+# GitHub Action: Repo SemVer
 
 [![CI](https://github.com/lhstrh/greatest-semver-tag/actions/workflows/ci.yml/badge.svg)](https://github.com/lhstrh/greatest-semver-tag/actions/workflows/ci.yml)
 
-This GitHub Action sorts through a given repository's tags and outputs the greatest according to the [rules of semantic versioning](https://semver.org/). In addition, it outputs "release", "major", "minor", "patch", "prerelease", and "build" increments. When given a specific semver increment, it will also output the requested version bump with respect to the current version in a separate "bump" output. When given the version number of a release planned for the future, this action also reports whether it is indeed greater than the current version. This action is primarily intended as a utility for use in release automation workflows.
+This GitHub Action sorts through a given repository's tags and returns the greatest according to the [rules of semantic versioning](https://semver.org/) on its `tag` output, along with a clean semver stripped of any prefix on its `current` output. This action is primarily intended as a utility for use in release automation workflows.
+
+**Obtaining version increments**
+
+The `release`, `major`, `minor`, `patch`, `prerelease`, and `build` outputs yield a semver that has a corresponding increment over the `current` output.
+
+**Requesting a specific version bump**
+
+If a `bump` input is given (e.g., "minor" or "release"), the `bump` output yields the requested semver with respect to `current`.
+
+**Validating planned a version**
+
+When given a semver on the `planned` input, this action reports whether the given version is indeed greater than `current` on the `planned-is-valid` output. 
 
 ## Usage
 In the `steps` of a job, specify the following:
 ```
 - name: Repo SemVer
-  uses: lhstrh/action-repo-semver@v1.1.1
+  uses: lhstrh/action-repo-semver@v1.1.2
   id: repo-semver
   with:
     bump: patch
@@ -38,9 +50,9 @@ Note that the `tag` output is "as-is", including any prefix the semver might hav
 * `repo` If specified, this repository is checked out by the action. By default, no checkout occurs.
 * `path` Location to find the repository checkout. By default, this is `$github.workspace`.
 * `bump` If specified, the `bump` output will reflect the given version increment with respect to `current`.
-* `build` If specified, the `next-build` output will be generated featuring this string (and remain empty otherwise).
 * `planned` If this is a valid semver greater than the `current` output, the `valid-planned` output is `true`.
-* `post-planned` If this is a valid semver greater than the `planned` input, the `valid-post-planned` output is `true`.
+* `build` If specified, the `next-build` output will be generated featuring this string (and remain empty otherwise).
+* `prerelease` If specified, the `next-prerelease` output will be generated featuring this string (and remain empty otherwise).
 
 
 ## Outputs
@@ -56,8 +68,6 @@ Note that the `tag` output is "as-is", including any prefix the semver might hav
 * `next-release` The smallest release increment relative to `current`.
 * `next-build` A build increment relative to `current`.
 * `planned-is-valid` True if the `planned` input is a valid semver greater than the `current` output.
-* `post-planned-is-valid` True if the `post-planned` input is a valid semver greater than `planned` input.
-
 
 ## Examples
 * (prerelease) If `current` is `1.0.0`, then `next-prerelease` is `1.0.0-1`.

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
     - name: Test if planned input is greater than current
       id: test
       run: >
-        if [[ $(semver compare ${{ inputs.planned }} ${{ steps.find.outputs.ver }}) -eq 1 ]]; then
+        if [[ $(semver compare ${{ inputs.planned }} ${{ steps.cur.outputs.ver }}) -eq 1 ]]; then
           echo "::set-output name=greater::true"
         else
           echo "::set-output name=greater::false"

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     type: string
     description: Requested version increment in bump output
     required: false
+  planned:
+    type: string
+    description: Version to compare against current
+    required: false
   prerelease:
     type: string
     description: String to be used in the next-prerelease output
@@ -21,14 +25,6 @@ inputs:
   build:
     type: string
     description: String to be used in next-build output
-    required: false
-  planned:
-    type: string
-    description: Version of a planned release
-    required: false
-  post-planned:
-    type: string
-    description: Version after planned release
     required: false
 
 outputs:
@@ -65,9 +61,6 @@ outputs:
   planned-is-valid:
     description: True if planned input is valid semver greater than current
     value: ${{ steps.test.outputs.greater }}
-  post-planned-is-valid:
-    description: True if post-planned input is valid semver greater planned
-    value: ${{ steps.test-post.outputs.greater }}
 
 branding:
   icon: tag
@@ -118,26 +111,16 @@ runs:
         ver="${{ steps.cur.outputs.ver }}";
         echo "::set-output name=str::$(echo ${tag%"$ver"})"
       shell: bash
-    - name: Test if planned input is greater than output
+    - name: Test if planned input is greater than current
       id: test
       run: >
-        if [[ $(semver compare ${{ inputs.planned }} ${{ steps.find.outputs.tag }}) -eq 1 ]]; then
+        if [[ $(semver compare ${{ inputs.planned }} ${{ steps.find.outputs.ver }}) -eq 1 ]]; then
           echo "::set-output name=greater::true"
         else
           echo "::set-output name=greater::false"
         fi
       shell: bash
       if: ${{ inputs.planned != '' }}
-    - name: Test if post-planned input is greater than planned input
-      id: test-post
-      run: >
-        if [[ $(semver compare ${{ inputs.post-planned }} ${{ inputs.planned }}) -eq 1 ]]; then
-          echo "::set-output name=greater::true"
-        else
-          echo "::set-output name=greater::false"
-        fi
-      shell: bash
-      if: ${{ inputs.planned != '' && inputs.post-planned != '' }}
     - name: Produce increments
       id: incr
       run: |


### PR DESCRIPTION
This PR removes the `post-planned` input and `post-planned-is-valid` output (unnecessary), making the interface a bit cleaner. Docs are updated accordingly. Tests are also updated.